### PR TITLE
Add Copy derives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use core::ptr;
 /// take and return copies of the value.
 ///
 /// The size of this struct is the same as the size of the contained type.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Volatile<T: Copy>(T);
 
 impl<T: Copy> Volatile<T> {
@@ -143,7 +143,7 @@ impl<T: Copy> Volatile<T> {
 /// A volatile wrapper which only allows read operations.
 ///
 /// The size of this struct is the same as the contained type.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ReadOnly<T: Copy>(Volatile<T>);
 
 impl<T: Copy> ReadOnly<T> {
@@ -200,7 +200,7 @@ impl<T: Copy> ReadOnly<T> {
 /// A volatile wrapper which only allows write operations.
 ///
 /// The size of this struct is the same as the contained type.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct WriteOnly<T: Copy>(Volatile<T>);
 
 impl<T: Copy> WriteOnly<T> {


### PR DESCRIPTION
I've been improving my VBA buffer logic and found something I can't do.

```rust
#[repr(C)]
struct Row([Volatile<Character>; BUFFER_WIDTH]);

impl Row {
    fn blank() -> Row {
        Row(
            [Volatile::new(Character {
                ascii: b' ',
                color: ColorPair::new(Color::Black, Color::Black),
            }); BUFFER_WIDTH],
        )
    }
}
```

This is inconvenient, and there doesn't appear to be any good reason why Volatile doesn't implement Copy - the contents are required to by trait constraint - so I made a quick pull request.