### PR TITLE
Make Volatile derive Copy.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use core::ptr;
 /// take and return copies of the value.
 ///
 /// The size of this struct is the same as the size of the contained type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Volatile<T: Copy>(T);
 
 impl<T: Copy> Volatile<T> {


### PR DESCRIPTION
Hi there. This PR makes the `Volatile` struct derive Copy. I'm not sure whether this will have any negative or unintended consequences.

To clarify what this is needed for, I am currently looking to improve some of the VGA text buffer code in Philipp Oppermann's [blog_os](https://github.com/phil-opp/blog_os). This PR allows an optimisation to be made for which I will send a PR there too.