### PR TITLE
Remove `Debug` and `Clone` derives for `WriteOnly`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ impl<T: Copy> ReadOnly<T> {
 /// A volatile wrapper which only allows write operations.
 ///
 /// The size of this struct is the same as the contained type.
-#[derive(Debug, Clone, Default)]
+#[derive(Default)]
 pub struct WriteOnly<T: Copy>(Volatile<T>);
 
 impl<T: Copy> WriteOnly<T> {


### PR DESCRIPTION
Closes https://github.com/rust-osdev/volatile/issues/11

_Edit (phil-opp):_ This is a **breaking change**.