### PR TITLE
Replace feature "range_bounds_assert_len" with "slice_range"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![cfg_attr(feature = "unstable", feature(core_intrinsics))]
 #![cfg_attr(feature = "unstable", feature(const_generics))]
-#![cfg_attr(feature = "unstable", feature(range_bounds_assert_len))]
+#![cfg_attr(feature = "unstable", feature(slice_range))]
 #![cfg_attr(feature = "unstable", allow(incomplete_features))]
 #![warn(missing_docs)]
 
@@ -25,6 +25,7 @@ use core::{
 use core::{
     intrinsics,
     ops::{Range, RangeBounds},
+    slice::range,
 };
 
 /// Allows creating read-only and write-only `Volatile` values.
@@ -624,7 +625,7 @@ where
         let Range {
             start: src_start,
             end: src_end,
-        } = src.assert_len(self.reference.len());
+        } = range(src, ..self.reference.len());
         let count = src_end - src_start;
         assert!(
             dest <= self.reference.len() - count,


### PR DESCRIPTION
Fixes #20. See rust-lang/rust#81154 for details about the nightly change.