### PR TITLE
various improvements for the new design

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,7 +865,8 @@ impl<R, W> VolatilePtr<'_, [u8], Access<R, W>> {
     /// use volatile::VolatilePtr;
     /// use core::ptr::NonNull;
     ///
-    /// let mut buf = unsafe { VolatilePtr::new_read_write(NonNull::from(vec![0; 10].as_mut_slice())) };
+    /// let mut vec = vec![0; 10];
+    /// let mut buf = unsafe { VolatilePtr::new_read_write(NonNull::from(vec.as_mut_slice())) };
     /// buf.fill(1);
     /// assert_eq!(unsafe { buf.as_ptr().as_mut() }, &mut vec![1; 10]);
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,6 +863,38 @@ impl<T, R, W, const N: usize> VolatilePtr<'_, [T; N], Access<R, W>> {
             })
         }
     }
+
+    /// Converts an array reference to a shared slice.
+    ///
+    /// This makes it possible to use the methods defined on slices.
+    ///
+    /// ## Example
+    ///
+    /// Copying two elements into a volatile array reference using `copy_from_slice`:
+    ///
+    /// ```
+    /// # extern crate core;
+    /// use volatile::VolatilePtr;
+    /// use core::ptr::NonNull;
+    ///
+    /// let src = [1, 2];
+    /// let mut dst = [0, 0];
+    /// let mut volatile = unsafe { VolatilePtr::new_write_only(NonNull::from(&dst)) };
+    ///
+    /// // convert the `Volatile<[i32; 2]>` array reference to a `Volatile<[i32]>` slice
+    /// let mut volatile_slice = volatile.as_slice_mut();
+    /// // we can now use the slice methods
+    /// volatile_slice.copy_from_slice(&src);
+    ///
+    /// assert_eq!(dst, [1, 2]);
+    /// ```
+    pub fn as_slice_mut<'a>(&'a mut self) -> VolatilePtr<'a, [T], Access<R, W>> {
+        unsafe {
+            self.map_mut(|array| {
+                NonNull::new(ptr::slice_from_raw_parts_mut(array.as_ptr() as *mut T, N)).unwrap()
+            })
+        }
+    }
 }
 
 /// Methods for restricting access.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,6 +535,7 @@ impl<'a, T, R, W> VolatilePtr<'a, [T], Access<R, W>> {
     pub fn copy_into_slice(&self, dst: &mut [T])
     where
         T: Copy,
+        R: access::Safe,
     {
         let len = self.pointer.len();
         assert_eq!(
@@ -591,6 +592,7 @@ impl<'a, T, R, W> VolatilePtr<'a, [T], Access<R, W>> {
     pub fn copy_from_slice(&mut self, src: &[T])
     where
         T: Copy,
+        W: access::Safe,
     {
         let len = self.pointer.len();
         assert_eq!(
@@ -644,6 +646,8 @@ impl<'a, T, R, W> VolatilePtr<'a, [T], Access<R, W>> {
     pub fn copy_within(&mut self, src: impl RangeBounds<usize>, dest: usize)
     where
         T: Copy,
+        R: access::Safe,
+        W: access::Safe,
     {
         let len = self.pointer.len();
         // implementation taken from https://github.com/rust-lang/rust/blob/683d1bcd405727fcc9209f64845bd3b9104878b8/library/core/src/slice/mod.rs#L2726-L2738
@@ -819,7 +823,7 @@ impl<'a, T, R, W> VolatilePtr<'a, [T], Access<R, W>> {
 
 /// Methods for volatile byte slices
 #[cfg(feature = "unstable")]
-impl<A> VolatilePtr<'_, [u8], A> {
+impl<R, W> VolatilePtr<'_, [u8], Access<R, W>> {
     /// Sets all elements of the byte slice to the given `value` using a volatile `memset`.
     ///
     /// This method is similar to the `slice::fill` method of the standard library, with the
@@ -841,7 +845,10 @@ impl<A> VolatilePtr<'_, [u8], A> {
     /// buf.fill(1);
     /// assert_eq!(unsafe { buf.as_ptr().as_mut() }, &mut vec![1; 10]);
     /// ```
-    pub fn fill(&mut self, value: u8) {
+    pub fn fill(&mut self, value: u8)
+    where
+        W: access::Safe,
+    {
         unsafe {
             intrinsics::volatile_set_memory(self.pointer.as_mut_ptr(), value, self.pointer.len());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,6 +476,24 @@ impl<'a, T, R, W> VolatilePtr<'a, [T], Access<R, W>> {
         }
     }
 
+    /// Returns an iterator over the slice.
+    pub fn iter<'b>(
+        &'b self,
+    ) -> impl Iterator<Item = VolatilePtr<'b, T, Access<R, access::NoAccess>>> + 'b {
+        let len = self.len();
+        (0..len).map(move |i| self.index(i))
+    }
+
+    /// Returns an iterator that allows modifying each value.
+    pub fn iter_mut<'b>(
+        &'b mut self,
+    ) -> impl Iterator<Item = VolatilePtr<'b, T, Access<R, W>>> + 'b {
+        let ptr = self.as_ptr().as_ptr() as *mut T;
+        let len = self.len();
+        (0..len)
+            .map(move |i| unsafe { VolatilePtr::new_generic(NonNull::new_unchecked(ptr.add(i))) })
+    }
+
     /// Copies all elements from `self` into `dst`, using a volatile memcpy.
     ///
     /// The length of `dst` must be the same as `self`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,10 @@ impl<'a, T, R, W> VolatilePtr<'a, [T], Access<R, W>> {
         self.pointer.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.pointer.len() == 0
+    }
+
     /// Applies the index operation on the wrapped slice.
     ///
     /// Returns a shared `Volatile` reference to the resulting subslice.


### PR DESCRIPTION
This pr brings various improvements for the new design:
- all methods take `Self` by value, not by reference
  - see https://github.com/rust-osdev/volatile/pull/22#discussion_r858819677
- ~implement `Copy` for `VolatilePtr`~
  - ~This is a requirement for the previous change. `VolatilePtr<'a, T>` now behaves a lot like `&'a Cell<T>` in that it allows reading and writing to a memory location with a copy-able non-unique handle.~ Replaced by `borrow` and `borrow_mut`.
  - See https://github.com/Freax13/volatile/tree/copy-again for a branch that still has this change
- add `VolatilePtr::as_slice_mut`
  - `VolatilePtr::as_slice` already existed, but didn't give out writable `VolatilePtr`s
- add `VolatilePtr::iter` and `VolatilePtr::iter_mut` to make it easier to iterator over all elements of a slice
- add `VolatilePtr::<[T]>::is_empty`
  - we already had `VolatilePtr::<[T]>::len`, so users would probably expect `.is_empty()` to work too
- add some missing where bounds to methods that read or write memory
- make `map_field!` reject unaligned fields
- ~add `#[inline]` to most functions~ Generic types are inlineable anyways

I didn't want to create multiple prs, so this pr has unrelated changes. Feel free to pick and choose which improvements you want to use in the new design.

I've been using the new design pretty much since #22 was created. I worked around some of the missing functions (e.g. `as_slice_mut`), but I couldn't do that for some of the bigger changes such as making methods take `Self` by value. So, instead of adding a new layer of workarounds, I decided to ignore that the #22 is not done yet and create a pr to it.

Related to https://github.com/rust-osdev/volatile/pull/22