### PR TITLE
Implement some useful traits

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add implementations for `fmt::Pointer`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`.
+
 # 0.5.1 – 2023-06-24
 
 - Fix: Add missing documentation of the `map` macro

--- a/src/volatile_ptr/mod.rs
+++ b/src/volatile_ptr/mod.rs
@@ -1,4 +1,4 @@
-use core::{fmt, marker::PhantomData, ptr::NonNull};
+use core::{cmp::Ordering, fmt, hash, marker::PhantomData, ptr::NonNull};
 
 use crate::access::ReadWrite;
 
@@ -47,12 +47,59 @@ where
 
 impl<T, A> fmt::Debug for VolatilePtr<'_, T, A>
 where
-    T: Copy + fmt::Debug + ?Sized,
+    T: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VolatilePtr")
             .field("pointer", &self.pointer)
             .field("access", &self.access)
             .finish()
+    }
+}
+
+impl<T, A> fmt::Pointer for VolatilePtr<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.pointer.as_ptr(), f)
+    }
+}
+
+impl<T, A> PartialEq for VolatilePtr<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        core::ptr::eq(self.pointer.as_ptr(), other.pointer.as_ptr())
+    }
+}
+
+impl<T, A> Eq for VolatilePtr<'_, T, A> where T: ?Sized {}
+
+impl<T, A> PartialOrd for VolatilePtr<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(&self.pointer.as_ptr(), &other.pointer.as_ptr()))
+    }
+}
+
+impl<T, A> Ord for VolatilePtr<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&self.pointer.as_ptr(), &other.pointer.as_ptr())
+    }
+}
+
+impl<T, A> hash::Hash for VolatilePtr<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.pointer.as_ptr().hash(state);
     }
 }

--- a/src/volatile_ptr/mod.rs
+++ b/src/volatile_ptr/mod.rs
@@ -50,10 +50,7 @@ where
     T: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("VolatilePtr")
-            .field("pointer", &self.pointer)
-            .field("access", &self.access)
-            .finish()
+        fmt::Pointer::fmt(&self.pointer.as_ptr(), f)
     }
 }
 

--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -2,7 +2,7 @@ use crate::{
     access::{Access, Copyable, ReadOnly, ReadWrite, WriteOnly},
     volatile_ptr::VolatilePtr,
 };
-use core::{fmt, marker::PhantomData, ptr::NonNull};
+use core::{cmp::Ordering, fmt, hash, marker::PhantomData, ptr::NonNull};
 
 /// Volatile pointer type that respects Rust's aliasing rules.
 ///
@@ -11,6 +11,9 @@ use core::{fmt, marker::PhantomData, ptr::NonNull};
 /// - it requires exclusive `&mut self` access for mutability
 /// - only read-only types implement [`Clone`] and [`Copy`]
 /// - [`Send`] and [`Sync`] are implemented if `T: Sync`
+///
+/// However, trait implementations like [`fmt::Debug`] and [`Eq`] behave like they do on pointer
+/// types and don't access the referenced value.
 ///
 /// To perform volatile operations on `VolatileRef` types, use the [`as_ptr`][Self::as_ptr]
 /// or [`as_mut_ptr`](Self::as_mut_ptr) methods to create a temporary
@@ -239,12 +242,59 @@ unsafe impl<T, A> Sync for VolatileRef<'_, T, A> where T: Sync {}
 
 impl<T, A> fmt::Debug for VolatileRef<'_, T, A>
 where
-    T: Copy + fmt::Debug + ?Sized,
+    T: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VolatileRef")
             .field("pointer", &self.pointer)
             .field("access", &self.access)
             .finish()
+    }
+}
+
+impl<T, A> fmt::Pointer for VolatileRef<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Pointer::fmt(&self.pointer.as_ptr(), f)
+    }
+}
+
+impl<T, A> PartialEq for VolatileRef<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        core::ptr::eq(self.pointer.as_ptr(), other.pointer.as_ptr())
+    }
+}
+
+impl<T, A> Eq for VolatileRef<'_, T, A> where T: ?Sized {}
+
+impl<T, A> PartialOrd for VolatileRef<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(Ord::cmp(&self.pointer.as_ptr(), &other.pointer.as_ptr()))
+    }
+}
+
+impl<T, A> Ord for VolatileRef<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&self.pointer.as_ptr(), &other.pointer.as_ptr())
+    }
+}
+
+impl<T, A> hash::Hash for VolatileRef<'_, T, A>
+where
+    T: ?Sized,
+{
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.pointer.as_ptr().hash(state);
     }
 }

--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -245,10 +245,7 @@ where
     T: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("VolatileRef")
-            .field("pointer", &self.pointer)
-            .field("access", &self.access)
-            .finish()
+        fmt::Pointer::fmt(&self.pointer.as_ptr(), f)
     }
 }
 


### PR DESCRIPTION
Add implementations for `fmt::Pointer`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` in analogy to [`NonNull`](https://doc.rust-lang.org/stable/core/ptr/struct.NonNull.html).

In the second commit, I shorten the output of `fmt::Debug` (which is now also analogous to `NonNull`) because printing out `VolatilePtr` as an entire struct every time `{:#?}` formatting is used makes debug output harder to read. I can revert that commit if you disagree.

I also removed the `T: Copy + fmt::Debug` bounds on the `fmt::Debug` implementations because they made no sense to me.