### PR TITLE
Remove `Sized` requirement for `Send` and `Sync` on `VolatileRef`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - Add implementations for `fmt::Pointer`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`.
 - Update `very_unstable` feature to latest nightly
+- Remove `Sized` requirement for `Send` and `Sync` impls on `VolatileRef`
 
 # 0.5.1 – 2023-06-24
 

--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -234,8 +234,8 @@ where
 {
 }
 
-unsafe impl<T, A> Send for VolatileRef<'_, T, A> where T: Sync {}
-unsafe impl<T, A> Sync for VolatileRef<'_, T, A> where T: Sync {}
+unsafe impl<T, A> Send for VolatileRef<'_, T, A> where T: Sync + ?Sized {}
+unsafe impl<T, A> Sync for VolatileRef<'_, T, A> where T: Sync + ?Sized {}
 
 impl<T, A> fmt::Debug for VolatileRef<'_, T, A>
 where


### PR DESCRIPTION
This requirement was unecessary, and `VolatileRef<T>` better mirrors `&T` without it.