### PR TITLE
Fix clippy warning about clone implementation

### DIFF
--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -222,11 +222,7 @@ where
     A: Access + Copyable,
 {
     fn clone(&self) -> Self {
-        Self {
-            pointer: self.pointer,
-            reference: self.reference,
-            access: self.access,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
Read-only `VolatileRef` instances implement `Copy`, so we should set the `Clone` implementation to just `*self` to ensure that `Clone` and `Copy` match. See https://rust-lang.github.io/rust-clippy/master/index.html#/non_canonical_clone_impl .