### PR TITLE
Add `VolatileRef::borrow` and `VolatileRef::borrow_mut`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `VolatileRef::borrow` and `VolatileRef::borrow_mut`
+
 # 0.5.2 – 2024-03-22
 
 - Add implementations for `fmt::Pointer`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`.

--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -134,6 +134,30 @@ impl<'a, T, A> VolatileRef<'a, T, A>
 where
     T: ?Sized,
 {
+    /// Immutably borrows from this `VolatileRef`.
+    ///
+    /// This method creates a `VolatileRef` tied to the lifetime of the `&VolatileRef` it is created from.
+    /// This is useful for providing a volatile reference without moving the original `VolatileRef`.
+    /// In comparison with creating a `&VolatileRef<'a, T>`, this avoids the additional indirection and lifetime.
+    pub fn borrow(&self) -> VolatileRef<'_, T, A::RestrictShared>
+    where
+        A: Access,
+    {
+        unsafe { VolatileRef::new_restricted(Default::default(), self.pointer) }
+    }
+
+    /// Mutably borrows from this `VolatileRef`.
+    ///
+    /// This method creates a `VolatileRef` tied to the lifetime of the `&mut VolatileRef` it is created from.
+    /// This is useful for providing a volatile reference without moving the original `VolatileRef`.
+    /// In comparison with creating a `&mut VolatileRef<'a, T>`, this avoids the additional indirection and lifetime.
+    pub fn borrow_mut(&mut self) -> VolatileRef<'_, T, A>
+    where
+        A: Access,
+    {
+        unsafe { VolatileRef::new_restricted(Default::default(), self.pointer) }
+    }
+
     /// Borrows this `VolatileRef` as a read-only [`VolatilePtr`].
     ///
     /// Use this method to do (partial) volatile reads of the referenced data.


### PR DESCRIPTION
These methods are useful when you want to borrow a `VolatileRef` but want to avoid the additional indirection and lifetime of `&mut VolatileRef<'a, T>` by creating a `VolatileRef<'_, T>` instead.

`borrow` and `borrow_mut` mirror `as_ptr` and `as_mut_ptr` respectively, but yield volatile references instead of pointers.