### PR TITLE
Enable all features and `doc_auto_cfg` on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ pre-release-replacements = [
 pre-release-commit-message = "Release version {{version}}"
 
 [package.metadata.docs.rs]
-features = ["unstable"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
 members = ["volatile-macro"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 #![cfg_attr(feature = "very_unstable", feature(unboxed_closures))]
 #![cfg_attr(feature = "very_unstable", feature(fn_traits))]
 #![cfg_attr(feature = "very_unstable", feature(effects))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![doc(test(attr(deny(warnings))))]


### PR DESCRIPTION
This makes sure the derive macro as well as the unstable features are shown on docs.rs, but with a note that these things are feature gated.

Closes https://github.com/rust-osdev/volatile/issues/54