### PR TITLE
feat: introduce `RestrictAccess<To>` and generalize `restrict` to all access types

### DIFF
--- a/src/access.rs
+++ b/src/access.rs
@@ -49,15 +49,15 @@ restrict_impl!(WriteOnly, NoAccess, NoAccess);
 pub trait Access: Copy + Default + private::Sealed {}
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`ReadOnly`].
-pub trait Readable: Copy + Default + private::Sealed {}
+pub trait Readable: Access {}
 impl<A: RestrictAccess<ReadOnly, Restricted = ReadOnly>> Readable for A {}
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`WriteOnly`].
-pub trait Writable: Access + private::Sealed {}
+pub trait Writable: Access {}
 impl<A: RestrictAccess<WriteOnly, Restricted = WriteOnly>> Writable for A {}
 
 /// Implemented for access types that permit copying of `VolatileRef`.
-pub trait Copyable: private::Sealed {}
+pub trait Copyable: Access {}
 impl<A: RestrictAccess<ReadOnly, Restricted = Self>> Copyable for A {}
 
 /// Zero-sized marker type for allowing both read and write access.

--- a/src/access.rs
+++ b/src/access.rs
@@ -70,21 +70,21 @@ impl<A: RestrictAccess<WriteOnly, Restricted = WriteOnly>> Writable for A {}
 pub trait Copyable: private::Sealed {}
 impl<A: RestrictAccess<ReadOnly, Restricted = Self>> Copyable for A {}
 
-impl<T> Access for T
-where
-    T: Readable + Default + Copy,
-{
-    #[allow(deprecated)]
-    type RestrictShared = <T as Readable>::RestrictShared;
-}
-
 /// Zero-sized marker type for allowing both read and write access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadWrite;
+impl Access for ReadWrite {
+    #[allow(deprecated)]
+    type RestrictShared = <Self as Readable>::RestrictShared;
+}
 
 /// Zero-sized marker type for allowing only read access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadOnly;
+impl Access for ReadOnly {
+    #[allow(deprecated)]
+    type RestrictShared = <Self as Readable>::RestrictShared;
+}
 
 /// Zero-sized marker type for allowing only write access.
 #[derive(Debug, Default, Copy, Clone)]

--- a/src/access.rs
+++ b/src/access.rs
@@ -61,6 +61,7 @@ pub trait Readable: Copy + Default + private::Sealed {
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`WriteOnly`].
 pub trait Writable: Access + private::Sealed {}
+impl<A: RestrictAccess<WriteOnly, Restricted = WriteOnly>> Writable for A {}
 
 /// Implemented for access types that permit copying of `VolatileRef`.
 pub trait Copyable: private::Sealed {}
@@ -80,7 +81,6 @@ pub struct ReadWrite;
 impl Readable for ReadWrite {
     type RestrictShared = ReadOnly;
 }
-impl Writable for ReadWrite {}
 
 /// Zero-sized marker type for allowing only read access.
 #[derive(Debug, Default, Copy, Clone)]
@@ -95,7 +95,6 @@ pub struct WriteOnly;
 impl Access for WriteOnly {
     type RestrictShared = NoAccess;
 }
-impl Writable for WriteOnly {}
 
 /// Zero-sized marker type that grants no access.
 #[derive(Debug, Default, Copy, Clone)]

--- a/src/access.rs
+++ b/src/access.rs
@@ -48,12 +48,14 @@ restrict_impl!(WriteOnly, NoAccess, NoAccess);
 /// Sealed trait that is implemented for the types in this module.
 pub trait Access: Copy + Default + private::Sealed {
     /// Reduced access level to safely share the corresponding value.
+    #[deprecated = "replaced by `RestrictAccess<ReadOnly>::Restricted`"]
     type RestrictShared: Access;
 }
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`ReadOnly`].
 pub trait Readable: Copy + Default + private::Sealed {
     /// Reduced access level to safely share the corresponding value.
+    #[deprecated = "replaced by `RestrictAccess<ReadOnly>::Restricted`"]
     type RestrictShared: Readable + Access;
 }
 
@@ -67,6 +69,7 @@ impl<T> Access for T
 where
     T: Readable + Default + Copy,
 {
+    #[allow(deprecated)]
     type RestrictShared = <T as Readable>::RestrictShared;
 }
 

--- a/src/access.rs
+++ b/src/access.rs
@@ -59,7 +59,7 @@ pub trait Readable: Copy + Default + private::Sealed {
     type RestrictShared: Readable + Access;
 }
 impl<A: RestrictAccess<ReadOnly, Restricted = ReadOnly>> Readable for A {
-    type RestrictShared = ReadOnly;
+    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
 }
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`WriteOnly`].
@@ -74,30 +74,28 @@ impl<A: RestrictAccess<ReadOnly, Restricted = Self>> Copyable for A {}
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadWrite;
 impl Access for ReadWrite {
-    #[allow(deprecated)]
-    type RestrictShared = <Self as Readable>::RestrictShared;
+    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
 }
 
 /// Zero-sized marker type for allowing only read access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadOnly;
 impl Access for ReadOnly {
-    #[allow(deprecated)]
-    type RestrictShared = <Self as Readable>::RestrictShared;
+    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
 }
 
 /// Zero-sized marker type for allowing only write access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WriteOnly;
 impl Access for WriteOnly {
-    type RestrictShared = NoAccess;
+    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
 }
 
 /// Zero-sized marker type that grants no access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct NoAccess;
 impl Access for NoAccess {
-    type RestrictShared = NoAccess;
+    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
 }
 
 mod private {

--- a/src/access.rs
+++ b/src/access.rs
@@ -46,21 +46,11 @@ restrict_impl!(WriteOnly, WriteOnly, WriteOnly);
 restrict_impl!(WriteOnly, NoAccess, NoAccess);
 
 /// Sealed trait that is implemented for the types in this module.
-pub trait Access: Copy + Default + private::Sealed {
-    /// Reduced access level to safely share the corresponding value.
-    #[deprecated = "replaced by `RestrictAccess<ReadOnly>::Restricted`"]
-    type RestrictShared: Access;
-}
+pub trait Access: Copy + Default + private::Sealed {}
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`ReadOnly`].
-pub trait Readable: Copy + Default + private::Sealed {
-    /// Reduced access level to safely share the corresponding value.
-    #[deprecated = "replaced by `RestrictAccess<ReadOnly>::Restricted`"]
-    type RestrictShared: Readable + Access;
-}
-impl<A: RestrictAccess<ReadOnly, Restricted = ReadOnly>> Readable for A {
-    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
-}
+pub trait Readable: Copy + Default + private::Sealed {}
+impl<A: RestrictAccess<ReadOnly, Restricted = ReadOnly>> Readable for A {}
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`WriteOnly`].
 pub trait Writable: Access + private::Sealed {}
@@ -73,30 +63,22 @@ impl<A: RestrictAccess<ReadOnly, Restricted = Self>> Copyable for A {}
 /// Zero-sized marker type for allowing both read and write access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadWrite;
-impl Access for ReadWrite {
-    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
-}
+impl Access for ReadWrite {}
 
 /// Zero-sized marker type for allowing only read access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadOnly;
-impl Access for ReadOnly {
-    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
-}
+impl Access for ReadOnly {}
 
 /// Zero-sized marker type for allowing only write access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WriteOnly;
-impl Access for WriteOnly {
-    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
-}
+impl Access for WriteOnly {}
 
 /// Zero-sized marker type that grants no access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct NoAccess;
-impl Access for NoAccess {
-    type RestrictShared = <Self as RestrictAccess<ReadOnly>>::Restricted;
-}
+impl Access for NoAccess {}
 
 mod private {
     pub trait Sealed {}

--- a/src/access.rs
+++ b/src/access.rs
@@ -64,6 +64,7 @@ pub trait Writable: Access + private::Sealed {}
 
 /// Implemented for access types that permit copying of `VolatileRef`.
 pub trait Copyable: private::Sealed {}
+impl<A: RestrictAccess<ReadOnly, Restricted = Self>> Copyable for A {}
 
 impl<T> Access for T
 where
@@ -87,7 +88,6 @@ pub struct ReadOnly;
 impl Readable for ReadOnly {
     type RestrictShared = ReadOnly;
 }
-impl Copyable for ReadOnly {}
 
 /// Zero-sized marker type for allowing only write access.
 #[derive(Debug, Default, Copy, Clone)]
@@ -103,7 +103,6 @@ pub struct NoAccess;
 impl Access for NoAccess {
     type RestrictShared = NoAccess;
 }
-impl Copyable for NoAccess {}
 
 mod private {
     pub trait Sealed {}

--- a/src/access.rs
+++ b/src/access.rs
@@ -58,6 +58,9 @@ pub trait Readable: Copy + Default + private::Sealed {
     #[deprecated = "replaced by `RestrictAccess<ReadOnly>::Restricted`"]
     type RestrictShared: Readable + Access;
 }
+impl<A: RestrictAccess<ReadOnly, Restricted = ReadOnly>> Readable for A {
+    type RestrictShared = ReadOnly;
+}
 
 /// Helper trait that is implemented by [`ReadWrite`] and [`WriteOnly`].
 pub trait Writable: Access + private::Sealed {}
@@ -78,16 +81,10 @@ where
 /// Zero-sized marker type for allowing both read and write access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadWrite;
-impl Readable for ReadWrite {
-    type RestrictShared = ReadOnly;
-}
 
 /// Zero-sized marker type for allowing only read access.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct ReadOnly;
-impl Readable for ReadOnly {
-    type RestrictShared = ReadOnly;
-}
 
 /// Zero-sized marker type for allowing only write access.
 #[derive(Debug, Default, Copy, Clone)]

--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -139,9 +139,9 @@ where
     /// This method creates a `VolatileRef` tied to the lifetime of the `&VolatileRef` it is created from.
     /// This is useful for providing a volatile reference without moving the original `VolatileRef`.
     /// In comparison with creating a `&VolatileRef<'a, T>`, this avoids the additional indirection and lifetime.
-    pub fn borrow(&self) -> VolatileRef<'_, T, A::RestrictShared>
+    pub fn borrow(&self) -> VolatileRef<'_, T, A::Restricted>
     where
-        A: Access,
+        A: RestrictAccess<ReadOnly>,
     {
         unsafe { VolatileRef::new_restricted(Default::default(), self.pointer) }
     }
@@ -161,9 +161,9 @@ where
     /// Borrows this `VolatileRef` as a read-only [`VolatilePtr`].
     ///
     /// Use this method to do (partial) volatile reads of the referenced data.
-    pub fn as_ptr(&self) -> VolatilePtr<'_, T, A::RestrictShared>
+    pub fn as_ptr(&self) -> VolatilePtr<'_, T, A::Restricted>
     where
-        A: Access,
+        A: RestrictAccess<ReadOnly>,
     {
         unsafe { VolatilePtr::new_restricted(Default::default(), self.pointer) }
     }

--- a/src/volatile_ref.rs
+++ b/src/volatile_ref.rs
@@ -1,5 +1,5 @@
 use crate::{
-    access::{Access, Copyable, ReadOnly, ReadWrite, WriteOnly},
+    access::{Access, Copyable, ReadOnly, ReadWrite, RestrictAccess, WriteOnly},
     volatile_ptr::VolatilePtr,
 };
 use core::{cmp::Ordering, fmt, hash, marker::PhantomData, ptr::NonNull};
@@ -194,7 +194,7 @@ where
 }
 
 /// Methods for restricting access.
-impl<'a, T> VolatileRef<'a, T, ReadWrite>
+impl<'a, T, A> VolatileRef<'a, T, A>
 where
     T: ?Sized,
 {
@@ -203,7 +203,7 @@ where
     /// ## Example
     ///
     /// ```
-    /// use volatile::access::ReadOnly;
+    /// use volatile::access::{ReadOnly, WriteOnly};
     /// use volatile::VolatileRef;
     ///
     /// let mut value: i16 = -4;
@@ -212,14 +212,24 @@ where
     /// let read_only = volatile.restrict::<ReadOnly>();
     /// assert_eq!(read_only.as_ptr().read(), -4);
     /// // read_only.as_ptr().write(10); // compile-time error
+    ///
+    /// let no_access = read_only.restrict::<WriteOnly>();
+    /// // no_access.read(); // compile-time error
+    /// // no_access.write(10); // compile-time error
     /// ```
-    pub fn restrict<A>(self) -> VolatileRef<'a, T, A>
+    pub fn restrict<To>(self) -> VolatileRef<'a, T, A::Restricted>
     where
-        A: Access,
+        A: RestrictAccess<To>,
     {
         unsafe { VolatileRef::new_restricted(Default::default(), self.pointer) }
     }
+}
 
+/// Methods for restricting access.
+impl<'a, T> VolatileRef<'a, T, ReadWrite>
+where
+    T: ?Sized,
+{
     /// Restricts access permissions to read-only.
     ///
     /// ## Example


### PR DESCRIPTION
This PR introduces `trait RestrictAccess<T>` to generalize the restriction from any access type to any other access type, to implement `Volatile{Ptr,Ref}::restrict` generically for all access types.

While not required, this PR also replaces and deprecates `Access::RestrictShared`, since it is equivalent to `RestrictAccess<ReadOnly>::Restricted`.

Though also optional, I implemented `Readable`, `Writable`, and `Copyable` in terms of `RestrictAccess`.

This PR depends on https://github.com/rust-osdev/volatile/pull/59.