### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rust-osdev/volatile"
 edition = "2021"
 
 [dependencies]
-volatile-macro = { version = "=0.5.4", optional = true, path = "volatile-macro" }
+volatile-macro = { version = "=0.6.0", optional = true, path = "volatile-macro" }
 
 [features]
 derive = ["dep:volatile-macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volatile"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 license = "MIT OR Apache-2.0"
 keywords = ["volatile"]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.6.0 – 2024-06-06
+
 * **Breaking:** feat: introduce `RestrictAccess<To>` and generalize `restrict` to all access types by @mkroening in https://github.com/rust-osdev/volatile/pull/60
 * feat: implement derive macro for all access types by @mkroening in https://github.com/rust-osdev/volatile/pull/61
 * fix: add `#[must_use]` to volatile types, `read`, and `as_raw_ptr` by @mkroening in https://github.com/rust-osdev/volatile/pull/58

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+* **Breaking:** feat: introduce `RestrictAccess<To>` and generalize `restrict` to all access types by @mkroening in https://github.com/rust-osdev/volatile/pull/60
+* feat: implement derive macro for all access types by @mkroening in https://github.com/rust-osdev/volatile/pull/61
+* fix: add `#[must_use]` to volatile types, `read`, and `as_raw_ptr` by @mkroening in https://github.com/rust-osdev/volatile/pull/58
+* Add a semver checks CI job by @phil-opp in https://github.com/rust-osdev/volatile/pull/63
+
+**Full Changelog**: https://github.com/rust-osdev/volatile/compare/v0.5.4...0.6.0
+
 # 0.5.4 – 2024-04-26
 
 * fix(access): properly seal access traits by @mkroening in https://github.com/rust-osdev/volatile/pull/59

--- a/volatile-macro/Cargo.toml
+++ b/volatile-macro/Cargo.toml
@@ -18,4 +18,4 @@ quote = "1"
 syn = { version = "2", features = ["full"] }
 
 [dev-dependencies]
-volatile = { version = "=0.5.4", path = "..", features = ["derive"] }
+volatile = { version = "=0.6.0", path = "..", features = ["derive"] }

--- a/volatile-macro/Cargo.toml
+++ b/volatile-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volatile-macro"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Martin Kröning <mkroening@posteo.net>"]
 edition = "2021"
 description = "Procedural macros for the volatile crate."


### PR DESCRIPTION
## What's Changed
* Add a semver checks CI job by @phil-opp in https://github.com/rust-osdev/volatile/pull/63
* feat: introduce `RestrictAccess<To>` and generalize `restrict` to all access types by @mkroening in https://github.com/rust-osdev/volatile/pull/60
* feat: implement derive macro for all access types by @mkroening in https://github.com/rust-osdev/volatile/pull/61
* fix: add `#[must_use]` to volatile types, `read`, and `as_raw_ptr` by @mkroening in https://github.com/rust-osdev/volatile/pull/58


**Full Changelog**: https://github.com/rust-osdev/volatile/compare/v0.5.4...0.6.0